### PR TITLE
Add authed fetch helper and refine community routes

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -2,27 +2,40 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
 
+    function isAdmin() {
+      return request.auth != null && request.auth.token.roles.hasAny(['admin']);
+    }
+
     match /community/{postId} {
-      allow read: if true;
+      allow read: if resource.data.status != 'hidden' || isAdmin();
 
-      // 로그인한 사용자는 discussion/design_share만 생성 가능
       allow create: if request.auth != null
-        && request.resource.data.type in ['discussion', 'design_share']
         && request.resource.data.author.uid == request.auth.uid
-        && request.resource.data.productId is string
-        && request.resource.data.title is string
-        && request.resource.data.body is string;
+        && (
+          (request.resource.data.type == 'notice' && isAdmin())
+          || (
+            request.resource.data.type in ['discussion', 'design_share']
+            && request.resource.data.productId is string
+            && request.resource.data.title is string
+            && request.resource.data.body is string
+          )
+        );
 
-      // 작성자만 수정/삭제 가능
-      allow update, delete: if request.auth != null
-        && resource.data.author.uid == request.auth.uid;
+      allow update: if request.auth != null && (
+        (resource.data.author.uid == request.auth.uid && request.resource.data.status == resource.data.status)
+        || isAdmin()
+      );
+
+      allow delete: if request.auth != null &&
+        (resource.data.author.uid == request.auth.uid || isAdmin());
     }
 
     match /community/{postId}/attachments/{fileId} {
-      allow read: if true;   // 공개 다운로드
-      // 글 작성자만 첨부 추가/삭제 가능
-      allow create, delete: if request.auth != null
-        && get(/databases/$(database)/documents/community/$(postId)).data.author.uid == request.auth.uid;
+      allow read: if true;
+      allow create, delete: if request.auth != null && (
+        get(/databases/$(database)/documents/community/$(postId)).data.author.uid == request.auth.uid
+        || isAdmin()
+      );
     }
 
     // products/{pid}/likes/{uid} — 로그인한 본인만 토글 가능

--- a/next.config.ts
+++ b/next.config.ts
@@ -19,6 +19,15 @@ const nextConfig: NextConfig = {
       }
     ],
   },
+  webpack: (config) => {
+    config.resolve.alias['@opentelemetry/exporter-jaeger'] = false;
+    config.resolve.alias['@genkit-ai/firebase'] = false;
+    config.resolve.alias['@genkit-ai/core'] = false;
+    config.resolve.alias['genkit'] = false;
+    config.resolve.alias['dotprompt'] = false;
+    config.resolve.alias['handlebars'] = false;
+    return config;
+  },
 };
 
 export default nextConfig;

--- a/src/app/api/community/attachments/[attachmentId]/download/route.ts
+++ b/src/app/api/community/attachments/[attachmentId]/download/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from 'next/server';
+import { getFirestore, FieldPath, FieldValue } from '@/lib/firebase.admin';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ attachmentId: string }> },
+) {
+  try {
+    const { attachmentId } = await params;
+    const db = getFirestore();
+    const snap = await db
+      .collectionGroup('attachments')
+      .where(FieldPath.documentId(), '==', attachmentId)
+      .limit(1)
+      .get();
+
+    if (snap.empty)
+      return NextResponse.json({ error: 'not-found' }, { status: 404 });
+
+    const doc = snap.docs[0];
+    const url = doc.get('downloadURL') as string | undefined;
+    if (!url)
+      return NextResponse.json({ error: 'missing-url' }, { status: 500 });
+
+    await doc.ref.update({ downloadCount: FieldValue.increment(1) });
+
+    return NextResponse.redirect(url, 302);
+  } catch (e) {
+    const message = e instanceof Error ? e.message : undefined;
+    const status = message?.includes('document path') ? 404 : 500;
+    return NextResponse.json(
+      { error: status === 404 ? 'not-found' : 'internal', detail: message },
+      { status },
+    );
+  }
+}

--- a/src/app/api/community/posts/[postId]/report/route.ts
+++ b/src/app/api/community/posts/[postId]/report/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from 'next/server';
+import { getAuth, getFirestore, FieldValue, Timestamp } from '@/lib/firebase.admin';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+async function verify(req: Request) {
+  const auth = getAuth();
+  const token = (req.headers.get('authorization') || '').replace(/^Bearer\s+/i, '');
+  if (!token) throw new Error('no-token');
+  const decoded = await auth.verifyIdToken(token);
+  return decoded;
+}
+
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ postId: string }> },
+) {
+  try {
+    const { uid } = await verify(req);
+    const { reason = '' } = await req.json();
+    const db = getFirestore();
+    const { postId } = await params;
+    const postRef = db.collection('community').doc(postId);
+
+    const fiveMinAgo = Timestamp.fromMillis(Date.now() - 5 * 60 * 1000);
+    const dup = await postRef
+      .collection('reports')
+      .where('author.uid', '==', uid)
+      .where('createdAt', '>', fiveMinAgo)
+      .limit(1)
+      .get();
+    if (!dup.empty)
+      return NextResponse.json({ ok: false, dedup: true }, { status: 429 });
+
+    await postRef.collection('reports').add({
+      reason: String(reason).slice(0, 200),
+      author: { uid },
+      createdAt: FieldValue.serverTimestamp(),
+    });
+
+    return NextResponse.json({ ok: true });
+  } catch (e) {
+    return NextResponse.json({ ok: false, error: (e as Error).message }, { status: 401 });
+  }
+}

--- a/src/app/api/community/posts/[postId]/visibility/route.ts
+++ b/src/app/api/community/posts/[postId]/visibility/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server';
+import { getAuth, getFirestore } from '@/lib/firebase.admin';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+async function requireAdmin(req: Request) {
+  const token = (req.headers.get('authorization') || '').replace(/^Bearer\s+/i, '');
+  const dec = await getAuth().verifyIdToken(token);
+  if (!Array.isArray(dec.roles) || !dec.roles.includes('admin')) throw new Error('not-admin');
+  return dec;
+}
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: Promise<{ postId: string }> },
+) {
+  try {
+    await requireAdmin(req);
+    const { status } = await req.json();
+    const { postId } = await params;
+    await getFirestore().collection('community').doc(postId).update({ status });
+    return NextResponse.json({ ok: true });
+  } catch (e) {
+    return NextResponse.json({ ok: false, error: (e as Error).message }, { status: 403 });
+  }
+}

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,4 @@
+export const runtime = 'nodejs';
+export async function GET() {
+  return new Response('ok');
+}

--- a/src/app/community/[postId]/page.tsx
+++ b/src/app/community/[postId]/page.tsx
@@ -1,22 +1,25 @@
-"use client";
+'use client';
 
-import { useEffect, useState } from "react";
-import { useParams, useRouter } from "next/navigation";
-import { auth, db } from "@/lib/firebase.client";
+import { useEffect, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { auth, db } from '@/lib/firebase.client';
 import {
   collection,
   doc,
   getDoc,
   getDocs,
   deleteDoc,
-} from "firebase/firestore";
-import { track } from "@/lib/analytics";
+} from 'firebase/firestore';
+import { track } from '@/lib/analytics';
+import { useAuth } from '@/contexts/AuthContext';
+import { authedFetch } from '@/lib/authedFetch';
 
 interface Post {
   id: string;
   title: string;
   body: string;
   author?: { uid: string; [key: string]: unknown };
+  status?: string;
   [key: string]: unknown;
 }
 
@@ -33,47 +36,90 @@ export default function PostDetail() {
   const [post, setPost] = useState<Post | null>(null);
   const [files, setFiles] = useState<Attachment[]>([]);
   const router = useRouter();
+  const { user } = useAuth();
 
   useEffect(() => {
     (async () => {
-      const d = await getDoc(doc(db, "community", postId));
+      const d = await getDoc(doc(db, 'community', postId));
       const data = d.data();
-        if (data) {
-          setPost({ id: d.id, ...(data as Omit<Post, "id">) } as Post);
-        }
-        const a = await getDocs(collection(db, `community/${postId}/attachments`));
-        setFiles(
-          a.docs.map((docSnap) => {
-            const dData = docSnap.data() as Omit<Attachment, "id">;
-            return { id: docSnap.id, ...dData };
-          }) as Attachment[]
-        );
-      })();
+      if (data) {
+        setPost({ id: d.id, ...(data as Omit<Post, 'id'>) } as Post);
+      }
+      const a = await getDocs(
+        collection(db, `community/${postId}/attachments`),
+      );
+      setFiles(
+        a.docs.map((docSnap) => {
+          const dData = docSnap.data() as Omit<Attachment, 'id'>;
+          return { id: docSnap.id, ...dData };
+        }) as Attachment[],
+      );
+    })();
   }, [postId]);
 
   if (!post) return <div>불러오는 중…</div>;
 
   async function handleDelete() {
     if (!post) return;
-    if (!confirm("삭제하시겠습니까?")) return;
-    const snap = await getDocs(collection(db, `community/${postId}/attachments`));
+    if (!confirm('삭제하시겠습니까?')) return;
+    const snap = await getDocs(
+      collection(db, `community/${postId}/attachments`),
+    );
     await Promise.all(snap.docs.map((d) => deleteDoc(d.ref)));
-    await deleteDoc(doc(db, "community", postId));
-    alert("삭제되었습니다.");
+    await deleteDoc(doc(db, 'community', postId));
+    alert('삭제되었습니다.');
     router.replace(`/products/${post.productId}`);
   }
 
   const isAuthor = auth.currentUser?.uid === post.author?.uid;
+  const isAdmin = user?.isAdmin;
+
+  async function handleReport() {
+    if (!auth.currentUser) return alert('로그인이 필요합니다.');
+    const reason = prompt('신고 사유를 입력하세요') || '';
+    const res = await authedFetch(`/api/community/posts/${postId}/report`, {
+      method: 'POST',
+      body: JSON.stringify({ reason }),
+    });
+    if (res.status === 429) alert('잠시 후 다시 시도하세요.');
+    else if (!res.ok) alert('신고에 실패했습니다.');
+    else alert('신고되었습니다.');
+  }
+
+  async function toggleVisibility() {
+    if (!auth.currentUser) return;
+    const next = post?.status === 'hidden' ? 'active' : 'hidden';
+    const res = await authedFetch(`/api/community/posts/${postId}/visibility`, {
+      method: 'PATCH',
+      body: JSON.stringify({ status: next }),
+    });
+    if (res.ok) setPost((p) => (p ? { ...p, status: next } : p));
+  }
 
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
         <h1 className="text-xl font-bold">{post.title}</h1>
-        {isAuthor && (
-          <button onClick={handleDelete} className="text-red-600 text-sm">
-            삭제
-          </button>
-        )}
+        <div className="space-x-2">
+          {isAuthor && (
+            <button onClick={handleDelete} className="text-red-600 text-sm">
+              삭제
+            </button>
+          )}
+          {isAdmin && (
+            <button
+              onClick={toggleVisibility}
+              className="text-sm text-gray-600"
+            >
+              {post.status === 'hidden' ? '복구' : '숨기기'}
+            </button>
+          )}
+          {auth.currentUser && !isAdmin && (
+            <button onClick={handleReport} className="text-sm text-gray-600">
+              신고
+            </button>
+          )}
+        </div>
       </div>
       <p className="whitespace-pre-wrap">{post.body}</p>
 
@@ -82,12 +128,15 @@ export default function PostDetail() {
         {files.map((f) => (
           <li key={f.id}>
             <a
-              href={f.downloadURL}
+              href={`/api/community/attachments/${f.id}/download`}
               target="_blank"
               rel="noreferrer"
               className="text-blue-600 underline"
               onClick={() =>
-                track("download_design_pdf", { post_id: postId, file: f.fileName })
+                track('download_design_pdf', {
+                  post_id: postId,
+                  file: f.fileName,
+                })
               }
             >
               {f.fileName} ({Math.round((f.size || 0) / 1024 / 1024)}MB)
@@ -99,4 +148,3 @@ export default function PostDetail() {
     </div>
   );
 }
-

--- a/src/components/community/NoticeButton.tsx
+++ b/src/components/community/NoticeButton.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { useAuth } from '@/contexts/AuthContext';
+
+export default function NoticeButton({ onClick }: { onClick: () => void }) {
+  const { user } = useAuth();
+  if (!user?.isAdmin) return null;
+  return (
+    <Button type="button" onClick={onClick} variant="secondary">
+      공지 작성
+    </Button>
+  );
+}

--- a/src/components/community/PostCreate.tsx
+++ b/src/components/community/PostCreate.tsx
@@ -1,52 +1,52 @@
-"use client";
+'use client';
 
-import { useState } from "react";
-import { auth, db, storage } from "@/lib/firebase.client";
-import { addDoc, collection, serverTimestamp } from "firebase/firestore";
-import { track } from "@/lib/analytics";
-import { ref, uploadBytesResumable, getDownloadURL } from "firebase/storage";
+import { useState } from 'react';
+import { auth, db, storage } from '@/lib/firebase.client';
+import { addDoc, collection, serverTimestamp } from 'firebase/firestore';
+import { track } from '@/lib/analytics';
+import { ref, uploadBytesResumable, getDownloadURL } from 'firebase/storage';
+import NoticeButton from './NoticeButton';
 
-type Kind = "discussion" | "design_share";
+type Kind = 'discussion' | 'design_share' | 'notice';
 
 export default function PostCreate({ productId }: { productId: string }) {
-  const [title, setTitle] = useState("");
-  const [body, setBody] = useState("");
-  const [type, setType] = useState<Kind>("design_share");
+  const [title, setTitle] = useState('');
+  const [body, setBody] = useState('');
+  const [type, setType] = useState<Kind>('design_share');
   const [files, setFiles] = useState<FileList | null>(null);
   const [busy, setBusy] = useState(false);
   const [progress, setProgress] = useState<number>(0);
 
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
-    if (!auth.currentUser) return alert("로그인이 필요합니다.");
-    if (!title.trim()) return alert("제목을 입력하세요.");
+    if (!auth.currentUser) return alert('로그인이 필요합니다.');
+    if (!title.trim()) return alert('제목을 입력하세요.');
 
     setBusy(true);
     try {
       // 1) 커뮤니티 글 생성
-      const postRef = await addDoc(collection(db, "community"), {
+      const postRef = await addDoc(collection(db, 'community'), {
         productId,
         type,
+        status: 'active',
         title,
         body,
         author: {
           uid: auth.currentUser.uid,
           displayName:
-            auth.currentUser.displayName ||
-            auth.currentUser.email ||
-            "user",
+            auth.currentUser.displayName || auth.currentUser.email || 'user',
         },
         attachmentCount: 0,
         createdAt: serverTimestamp(),
         updatedAt: serverTimestamp(),
       });
 
-      track("create_community_post", { product_id: productId, type });
+      track('create_community_post', { product_id: productId, type });
 
       // 2) 파일 업로드 (선택)
       if (files && files.length > 0) {
         for (const file of Array.from(files)) {
-          if (file.type !== "application/pdf") {
+          if (file.type !== 'application/pdf') {
             alert(`PDF만 업로드 가능합니다: ${file.name}`);
             continue;
           }
@@ -58,13 +58,13 @@ export default function PostCreate({ productId }: { productId: string }) {
 
           await new Promise<void>((resolve, reject) => {
             task.on(
-              "state_changed",
+              'state_changed',
               (snap) =>
                 setProgress(
-                  Math.round((snap.bytesTransferred / snap.totalBytes) * 100)
+                  Math.round((snap.bytesTransferred / snap.totalBytes) * 100),
                 ),
               reject,
-              () => resolve()
+              () => resolve(),
             );
           });
 
@@ -77,21 +77,21 @@ export default function PostCreate({ productId }: { productId: string }) {
             downloadURL: url,
             createdAt: serverTimestamp(),
           });
-          track("upload_pdf_attachment", { post_id: postRef.id });
+          track('upload_pdf_attachment', { post_id: postRef.id });
         }
         // 첨부 개수 반영 (읽기용이라 생략해도 UX엔 큰 문제 없음)
         // await updateDoc(postRef, { attachmentCount: uploaded });
       }
 
-      alert("게시되었습니다.");
-      setTitle("");
-      setBody("");
-      (document.getElementById("files") as HTMLInputElement).value = "";
+      alert('게시되었습니다.');
+      setTitle('');
+      setBody('');
+      (document.getElementById('files') as HTMLInputElement).value = '';
       setFiles(null);
       setProgress(0);
     } catch (e: unknown) {
       console.error(e);
-      const message = e instanceof Error ? e.message : "업로드 실패";
+      const message = e instanceof Error ? e.message : '업로드 실패';
       alert(message);
     } finally {
       setBusy(false);
@@ -100,16 +100,21 @@ export default function PostCreate({ productId }: { productId: string }) {
 
   return (
     <form onSubmit={onSubmit} className="space-y-3">
-      <div className="flex gap-2">
-        <select
-          value={type}
-          onChange={(e) => setType(e.target.value as Kind)}
-          className="border rounded px-2 py-1"
-        >
-          <option value="design_share">디자인 공유</option>
-          <option value="discussion">토론</option>
-        </select>
-        {/* 공지는 임시 비활성(권한되면 추가) */}
+      <div className="flex gap-2 items-center">
+        {type !== 'notice' && (
+          <select
+            value={type}
+            onChange={(e) => setType(e.target.value as Kind)}
+            className="border rounded px-2 py-1"
+          >
+            <option value="design_share">디자인 공유</option>
+            <option value="discussion">토론</option>
+          </select>
+        )}
+        <NoticeButton onClick={() => setType('notice')} />
+        {type === 'notice' && (
+          <span className="text-sm text-yellow-600">공지 작성 모드</span>
+        )}
       </div>
       <input
         className="w-full border rounded px-3 py-2"
@@ -140,4 +145,3 @@ export default function PostCreate({ productId }: { productId: string }) {
     </form>
   );
 }
-

--- a/src/components/community/PostList.tsx
+++ b/src/components/community/PostList.tsx
@@ -1,8 +1,8 @@
-"use client";
+'use client';
 
-import Link from "next/link";
-import { useEffect, useState } from "react";
-import { db } from "@/lib/firebase.client";
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { db } from '@/lib/firebase.client';
 import {
   collection,
   getDocs,
@@ -13,7 +13,7 @@ import {
   startAfter,
   QueryDocumentSnapshot,
   DocumentData,
-} from "firebase/firestore";
+} from 'firebase/firestore';
 
 interface Item {
   id: string;
@@ -26,24 +26,24 @@ const PAGE = 10;
 
 export default function PostList({ productId }: { productId: string }) {
   const [items, setItems] = useState<Item[]>([]);
-  const [cursor, setCursor] = useState<QueryDocumentSnapshot<DocumentData> | null>(
-    null
-  );
+  const [cursor, setCursor] =
+    useState<QueryDocumentSnapshot<DocumentData> | null>(null);
   const [hasMore, setHasMore] = useState(true);
 
   async function load() {
     const base = [
-      where("productId", "==", productId),
-      orderBy("createdAt", "desc"),
+      where('productId', '==', productId),
+      where('status', '==', 'active'),
+      orderBy('createdAt', 'desc'),
       limit(PAGE),
     ];
     const q = cursor
-      ? query(collection(db, "community"), ...base, startAfter(cursor))
-      : query(collection(db, "community"), ...base);
+      ? query(collection(db, 'community'), ...base, startAfter(cursor))
+      : query(collection(db, 'community'), ...base);
     const snap = await getDocs(q);
     const docs = snap.docs.map((docSnap) => ({
       id: docSnap.id,
-      ...(docSnap.data() as Omit<Item, "id">),
+      ...(docSnap.data() as Omit<Item, 'id'>),
     }));
     setItems((prev) => [...prev, ...docs]);
     const last = snap.docs[snap.docs.length - 1] || null;
@@ -88,4 +88,3 @@ export default function PostList({ productId }: { productId: string }) {
     </div>
   );
 }
-

--- a/src/lib/authedFetch.ts
+++ b/src/lib/authedFetch.ts
@@ -1,0 +1,13 @@
+import { auth } from '@/lib/firebase.client';
+
+export async function authedFetch(input: RequestInfo, init: RequestInit = {}) {
+  const token = await auth.currentUser?.getIdToken(true);
+  return fetch(input, {
+    ...init,
+    headers: {
+      ...(init.headers || {}),
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+  });
+}

--- a/src/lib/firebase.admin.ts
+++ b/src/lib/firebase.admin.ts
@@ -1,0 +1,19 @@
+import { getApps, initializeApp, cert, applicationDefault } from 'firebase-admin/app';
+import { getAuth } from 'firebase-admin/auth';
+import { getFirestore, FieldValue, FieldPath, Timestamp } from 'firebase-admin/firestore';
+
+if (!getApps().length) {
+  initializeApp(
+    process.env.FB_PRIVATE_KEY
+      ? {
+          credential: cert({
+            projectId: process.env.FB_PROJECT_ID,
+            clientEmail: process.env.FB_CLIENT_EMAIL,
+            privateKey: process.env.FB_PRIVATE_KEY!.replace(/\\n/g, '\n'),
+          }),
+        }
+      : { credential: applicationDefault() }
+  );
+}
+
+export { getAuth, getFirestore, FieldValue, FieldPath, Timestamp };


### PR DESCRIPTION
## Summary
- add client-side `authedFetch` helper to attach Firebase ID tokens
- tighten community API routes with better error handling and health endpoint
- silence build warnings by aliasing unused modules

## Testing
- `npm run codex:type-check`
- `npm run codex:lint`
- `npm run codex:build`
- `curl -i http://localhost:3000/api/health`
- `curl -i http://localhost:3000/api/community/attachments/does-not-exist/download`
- `curl -s -o /tmp/report.body -D - -H "Content-Type: application/json" -d '{"reason":"test"}' http://localhost:3000/api/community/posts/test/report | head -n 20`
- `curl -s -o /tmp/vis.body -D - -X PATCH -H "Content-Type: application/json" -d '{"status":"hidden"}' http://localhost:3000/api/community/posts/test/visibility | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68a77a8ecaec8326a5b27984d18f7f8c