### PR TITLE
Add editor constants and canvas utility

### DIFF
--- a/src/editor/constants.ts
+++ b/src/editor/constants.ts
@@ -1,0 +1,12 @@
+export const DPI = 300;
+export const MM2PX = (mm: number) => Math.round((mm * DPI) / 25.4);
+export const PX2MM = (px: number) => (px * 25.4) / DPI;
+
+export const MATERIALS = {
+  acrylic: { thicknessMM: 3, minHoleDiameterMM: 3, minHoleEdgeClearanceMM: 2, minCornerRadiusMM: 1.5 },
+  wood: { thicknessMM: 4, minHoleDiameterMM: 4, minHoleEdgeClearanceMM: 2.5, minCornerRadiusMM: 2 },
+  sticker: { thicknessMM: 0.2, minHoleDiameterMM: 3, minHoleEdgeClearanceMM: 1.5, minCornerRadiusMM: 1 },
+};
+
+export const BLEED_MM = 8.0;
+export const SAFE_INNER_MM = 2.5;

--- a/src/editor/engine/canvas.ts
+++ b/src/editor/engine/canvas.ts
@@ -1,0 +1,18 @@
+/* eslint-disable import/no-unresolved */
+import { MM2PX } from "../constants";
+
+export async function createCanvas(
+  el: HTMLCanvasElement,
+  widthMM: number,
+  heightMM: number
+) {
+  const { fabric } = await import("fabric");
+  const canvas = new fabric.Canvas(el, {
+    width: MM2PX(widthMM),
+    height: MM2PX(heightMM),
+    selection: true,
+    preserveObjectStacking: true,
+  });
+  canvas.setZoom(1);
+  return canvas;
+}

--- a/src/types/modules.d.ts
+++ b/src/types/modules.d.ts
@@ -1,0 +1,4 @@
+declare module 'fabric';
+declare module 'image-tracerjs';
+declare module 'clipper-lib';
+declare module 'pdf-lib';


### PR DESCRIPTION
## Summary
- introduce shared editor constants for DPI conversion, material presets, and guide sizes
- add async canvas initializer leveraging Fabric.js and mm→px conversion
- declare stub modules for external editor libraries

## Testing
- `npx next lint`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68a78752a0848326aac587d0cee28abe