### PR TITLE
feat: add top banner management

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,11 +76,7 @@
     "@types/request": "^2.48.13",
     "eslint": "9.33.0",
     "eslint-config-next": "15.5.0",
-<<<<<<< HEAD
     "firebase-admin": "^13.4.0",
-=======
-    "firebase-admin": "^12.0.0",
->>>>>>> 95182ea539151542f5ea7d2f83ed05e8b64c5b6a
     "genkit-cli": "^1.14.1",
     "postcss": "^8",
     "prettier": "^3.3.3",

--- a/src/app/admin/banners/banner-form.tsx
+++ b/src/app/admin/banners/banner-form.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useForm, Controller } from 'react-hook-form';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Switch } from '@/components/ui/switch';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import type { Banner } from '@/lib/types';
+
+interface BannerFormData {
+  title: string;
+  content: string;
+  backgroundType: 'color' | 'image';
+  backgroundValue: string;
+  isOpen: boolean;
+  durationOption: 'day' | 'week';
+}
+
+export function BannerForm({ banner }: { banner?: Banner }) {
+  const router = useRouter();
+  const { register, handleSubmit, control } = useForm<BannerFormData>({
+    defaultValues:
+      banner || {
+        title: '',
+        content: '',
+        backgroundType: 'color',
+        backgroundValue: '#000000',
+        isOpen: true,
+        durationOption: 'day',
+      },
+  });
+
+  const onSubmit = async (data: BannerFormData) => {
+    if (banner) {
+      await fetch(`/api/banners/${banner.id}`, {
+        method: 'PUT',
+        body: JSON.stringify(data),
+      });
+    } else {
+      await fetch('/api/banners', {
+        method: 'POST',
+        body: JSON.stringify(data),
+      });
+    }
+    router.push('/admin/banners');
+  };
+
+  return (
+    <div className="container mx-auto max-w-2xl px-4 py-8">
+      <Card>
+        <CardHeader>
+          <CardTitle>{banner ? '배너 수정' : '배너 등록'}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+            <div>
+              <Label htmlFor="title">제목</Label>
+              <Input id="title" {...register('title', { required: true })} />
+            </div>
+            <div>
+              <Label htmlFor="content">내용</Label>
+              <Textarea id="content" rows={3} {...register('content')} />
+            </div>
+            <div className="grid gap-4 md:grid-cols-2">
+              <div>
+                <Label>배경 타입</Label>
+                <Controller
+                  name="backgroundType"
+                  control={control}
+                  render={({ field }) => (
+                    <Select value={field.value} onValueChange={field.onChange}>
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="color">색상</SelectItem>
+                        <SelectItem value="image">이미지</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  )}
+                />
+              </div>
+              <div>
+                <Label htmlFor="backgroundValue">값</Label>
+                <Input id="backgroundValue" {...register('backgroundValue')} />
+              </div>
+            </div>
+            <div className="flex items-center justify-between rounded-lg border p-4">
+              <div className="space-y-0.5">
+                <Label htmlFor="isOpen">공개 상태</Label>
+                <p className="text-sm text-muted-foreground">체크하면 사이트에 표시됩니다.</p>
+              </div>
+              <Controller
+                name="isOpen"
+                control={control}
+                render={({ field }) => <Switch id="isOpen" checked={field.value} onCheckedChange={field.onChange} />}
+              />
+            </div>
+            <div>
+              <Label>기간 옵션</Label>
+              <Controller
+                name="durationOption"
+                control={control}
+                render={({ field }) => (
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="day">오늘 하루</SelectItem>
+                      <SelectItem value="week">일주일</SelectItem>
+                    </SelectContent>
+                  </Select>
+                )}
+              />
+            </div>
+            <div className="flex justify-end gap-2">
+              <Button type="button" variant="outline" onClick={() => router.back()}>
+                취소
+              </Button>
+              <Button type="submit">저장하기</Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+

--- a/src/app/admin/banners/edit/[id]/page.tsx
+++ b/src/app/admin/banners/edit/[id]/page.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import { BannerForm } from '../../banner-form';
+import type { Banner } from '@/lib/types';
+
+export default function EditBannerPage() {
+  const params = useParams();
+  const { id } = params as { id: string };
+  const [banner, setBanner] = useState<Banner | null>(null);
+
+  useEffect(() => {
+    fetch(`/api/banners/${id}`).then(res => res.json()).then(setBanner);
+  }, [id]);
+
+  if (!banner) return <div className="p-4">Loading...</div>;
+
+  return <BannerForm banner={banner} />;
+}
+

--- a/src/app/admin/banners/new/page.tsx
+++ b/src/app/admin/banners/new/page.tsx
@@ -1,0 +1,6 @@
+import { BannerForm } from '../banner-form';
+
+export default function NewBannerPage() {
+  return <BannerForm />;
+}
+

--- a/src/app/admin/banners/page.tsx
+++ b/src/app/admin/banners/page.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import type { Banner } from '@/lib/types';
+import { Button } from '@/components/ui/button';
+import { Switch } from '@/components/ui/switch';
+
+export default function BannersPage() {
+  const [banners, setBanners] = useState<Banner[]>([]);
+
+  useEffect(() => {
+    fetch('/api/banners').then(res => res.json()).then(setBanners);
+  }, []);
+
+  const toggleOpen = async (banner: Banner) => {
+    await fetch(`/api/banners/${banner.id}`, {
+      method: 'PUT',
+      body: JSON.stringify({ isOpen: !banner.isOpen }),
+    });
+    setBanners(prev => prev.map(b => (b.id === banner.id ? { ...b, isOpen: !b.isOpen } : b)));
+  };
+
+  const deleteBanner = async (id: string) => {
+    await fetch(`/api/banners/${id}`, { method: 'DELETE' });
+    setBanners(prev => prev.filter(b => b.id !== id));
+  };
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <div className="mb-4 flex items-center justify-between">
+        <h1 className="text-2xl font-bold">배너 관리</h1>
+        <Button asChild>
+          <Link href="/admin/banners/new">배너등록</Link>
+        </Button>
+      </div>
+      <table className="w-full text-left text-sm">
+        <thead>
+          <tr className="border-b">
+            <th className="p-2">제목</th>
+            <th className="p-2">공개</th>
+            <th className="p-2">작업</th>
+          </tr>
+        </thead>
+        <tbody>
+          {banners.map(b => (
+            <tr key={b.id} className="border-b">
+              <td className="p-2">{b.title}</td>
+              <td className="p-2">
+                <Switch checked={b.isOpen} onCheckedChange={() => toggleOpen(b)} />
+              </td>
+              <td className="p-2 space-x-2">
+                <Button variant="outline" asChild size="sm">
+                  <Link href={`/admin/banners/edit/${b.id}`}>수정</Link>
+                </Button>
+                <Button variant="destructive" size="sm" onClick={() => deleteBanner(b.id)}>
+                  삭제
+                </Button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -14,6 +14,7 @@ const navItems = [
     { href: '/admin/faq', label: 'FAQ 관리', icon: HelpCircle },
     { href: '/admin/guide', label: '이용가이드 관리', icon: BookOpen },
     { href: '/admin/inquiries', label: '1:1 문의 관리', icon: MessageSquare },
+    { href: '/admin/banners', label: '배너 관리', icon: FileText },
 ]
 
 export default function AdminLayout({ children }: { children: ReactNode }) {

--- a/src/app/api/banners/[id]/route.ts
+++ b/src/app/api/banners/[id]/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+import { getFirestore, FieldValue } from '@/lib/firebase.admin';
+
+export async function GET(req: Request, { params }: { params: { id: string } }) {
+  const db = getFirestore();
+  const doc = await db.collection('banners').doc(params.id).get();
+  if (!doc.exists) return NextResponse.json(null, { status: 404 });
+  return NextResponse.json({ id: doc.id, ...doc.data() });
+}
+
+export async function PUT(req: Request, { params }: { params: { id: string } }) {
+  const data = await req.json();
+  const db = getFirestore();
+  await db.collection('banners').doc(params.id).update({
+    ...data,
+    updatedAt: FieldValue.serverTimestamp(),
+  });
+  return NextResponse.json({ id: params.id });
+}
+
+export async function DELETE(req: Request, { params }: { params: { id: string } }) {
+  const db = getFirestore();
+  await db.collection('banners').doc(params.id).delete();
+  return NextResponse.json({ id: params.id });
+}

--- a/src/app/api/banners/active/route.ts
+++ b/src/app/api/banners/active/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server';
+import { getFirestore } from '@/lib/firebase.admin';
+
+export async function GET() {
+  const db = getFirestore();
+  const snap = await db
+    .collection('banners')
+    .where('isOpen', '==', true)
+    .orderBy('createdAt', 'desc')
+    .limit(1)
+    .get();
+  if (snap.empty) return NextResponse.json(null);
+  const doc = snap.docs[0];
+  return NextResponse.json({ id: doc.id, ...doc.data() });
+}

--- a/src/app/api/banners/route.ts
+++ b/src/app/api/banners/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+import { getFirestore, FieldValue } from '@/lib/firebase.admin';
+
+export async function GET() {
+  const db = getFirestore();
+  const snap = await db.collection('banners').orderBy('createdAt', 'desc').get();
+  const banners = snap.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+  return NextResponse.json(banners);
+}
+
+export async function POST(req: Request) {
+  const data = await req.json();
+  const db = getFirestore();
+  const docRef = await db.collection('banners').add({
+    ...data,
+    createdAt: FieldValue.serverTimestamp(),
+    updatedAt: FieldValue.serverTimestamp(),
+  });
+  return NextResponse.json({ id: docRef.id });
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { Palette } from 'lucide-react';
 import { Providers } from '@/components/providers';
 import { Header } from '@/components/header';
 import { Footer } from '@/components/footer';
+import { TopBanner } from '@/components/top-banner';
 import { Toaster } from '@/components/ui/toaster';
 import { Button } from '@/components/ui/button';
 import { Chatbot } from '@/components/chatbot';
@@ -30,6 +31,7 @@ export default function RootLayout({
       <body className="font-body antialiased">
         <Providers>
           <div className="flex min-h-screen flex-col">
+            <TopBanner />
             <Header />
             <main className="flex-grow bg-background">{children}</main>
             <Footer />

--- a/src/components/top-banner.tsx
+++ b/src/components/top-banner.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { X } from 'lucide-react';
+import type { Banner } from '@/lib/types';
+
+export function TopBanner() {
+  const [banner, setBanner] = useState<Banner | null>(null);
+  const [hidden, setHidden] = useState(false);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch('/api/banners/active');
+        if (!res.ok) return;
+        const data = await res.json();
+        if (!data) return;
+        const hideUntil = localStorage.getItem(`banner_hide_${data.id}`);
+        if (hideUntil && new Date(hideUntil) > new Date()) {
+          return;
+        }
+        setBanner(data);
+      } catch (err) {
+        console.error(err);
+      }
+    }
+    load();
+  }, []);
+
+  const handleHide = (duration: 'day' | 'week') => {
+    if (!banner) return;
+    const days = duration === 'day' ? 1 : 7;
+    const until = new Date();
+    until.setDate(until.getDate() + days);
+    localStorage.setItem(`banner_hide_${banner.id}`, until.toISOString());
+    setHidden(true);
+  };
+
+  if (!banner || hidden) return null;
+
+  const style =
+    banner.backgroundType === 'color'
+      ? { backgroundColor: banner.backgroundValue }
+      : { backgroundImage: `url(${banner.backgroundValue})`, backgroundSize: 'cover' };
+
+  return (
+    <div className="w-full text-center text-white px-4 py-2" style={style}>
+      <div className="mx-auto flex max-w-screen-xl flex-col items-center gap-2 md:flex-row md:justify-center">
+        <div className="flex-1" dangerouslySetInnerHTML={{ __html: banner.content }} />
+        <div className="flex items-center gap-2 text-xs">
+          <label className="flex items-center gap-1 cursor-pointer">
+            <input type="checkbox" onChange={() => handleHide('day')} />
+            오늘 하루 보지 않기
+          </label>
+          <label className="flex items-center gap-1 cursor-pointer">
+            <input type="checkbox" onChange={() => handleHide('week')} />
+            일주일 간 보지 않기
+          </label>
+          <X className="h-4 w-4 cursor-pointer" onClick={() => setHidden(true)} />
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -75,6 +75,18 @@ export interface CartItem {
   };
 }
 
+export interface Banner {
+  id: string;
+  title: string;
+  content: string;
+  backgroundType: 'color' | 'image';
+  backgroundValue: string;
+  isOpen: boolean;
+  durationOption: 'day' | 'week';
+  createdAt: Date | import('firebase/firestore').Timestamp;
+  updatedAt: Date | import('firebase/firestore').Timestamp;
+}
+
 export interface User {
   id: string;
   email: string;


### PR DESCRIPTION
## Summary
- add responsive top banner component with dismiss options
- allow admin to create and toggle banners via CRUD pages
- expose Firestore API routes for banners
- resolve merge conflict in package.json so tooling works

## Testing
- `npm install --ignore-scripts` *(fails: 403 Forbidden - GET https://registry.npmjs.org/firebase-admin)*
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68a81fecbf2083269551c1242f948a18