### PR TITLE
feat: add responsive mega menu header

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 import { Palette } from 'lucide-react';
 import { Providers } from '@/components/providers';
-import { Header } from '@/components/header';
+import { Header } from '@/components/site/Header';
 import { Footer } from '@/components/footer';
 import { TopBanner } from '@/components/top-banner';
 import { Toaster } from '@/components/ui/toaster';

--- a/src/components/site/Header.tsx
+++ b/src/components/site/Header.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import Link from 'next/link';
+import { Search, ShoppingCart } from 'lucide-react';
+import { MegaMenu } from './MegaMenu';
+import { MenuTop, menuTops } from '@/lib/categories';
+
+/**
+ * 상단 헤더와 내비게이션 바를 렌더링합니다.
+ * - 데스크톱: hover로 메가메뉴 열기
+ * - 모바일: 탭으로 열기, 바깥 클릭 닫힘
+ * - 키보드: ←/→ 상단 이동, ↓ 열기, Esc 닫기
+ */
+export function Header() {
+  const [activeTop, setActiveTop] = useState<MenuTop | null>(null);
+  const [scrolled, setScrolled] = useState(false);
+  const btnRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  useEffect(() => {
+    const onScroll = () => setScrolled(window.scrollY > 100);
+    window.addEventListener('scroll', onScroll);
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
+  const visibleTops = menuTops.filter(t => t.show).sort((a, b) => a.order - b.order);
+
+  const handleKeyDown = (
+    e: React.KeyboardEvent<HTMLButtonElement>,
+    index: number,
+    item: MenuTop,
+  ) => {
+    const max = visibleTops.length;
+    switch (e.key) {
+      case 'ArrowRight':
+        e.preventDefault();
+        btnRefs.current[(index + 1) % max]?.focus();
+        break;
+      case 'ArrowLeft':
+        e.preventDefault();
+        btnRefs.current[(index - 1 + max) % max]?.focus();
+        break;
+      case 'ArrowDown':
+      case 'Enter':
+      case ' ': // space
+        e.preventDefault();
+        setActiveTop(item);
+        break;
+      case 'Escape':
+        setActiveTop(null);
+        (e.target as HTMLElement).blur();
+        break;
+    }
+  };
+
+  return (
+    <header
+      className={`sticky top-0 z-50 w-full bg-white ${scrolled ? 'shadow-md' : ''}`}
+    >
+      <div className="mx-auto flex h-12 items-center justify-between px-4">
+        <Link href="/" className="font-bold">PINTO</Link>
+        {/* Desktop Nav */}
+        <nav
+          className="hidden gap-6 md:flex"
+          role="menubar"
+        >
+          {visibleTops.map((item, i) => (
+            <button
+              key={item.id}
+              ref={el => {
+                btnRefs.current[i] = el;
+              }}
+              role="menuitem"
+              aria-haspopup={item.groups ? true : undefined}
+              aria-expanded={activeTop?.id === item.id}
+              className="text-sm font-medium hover:text-primary focus:outline-none"
+              onMouseEnter={() => setActiveTop(item)}
+              onFocus={() => setActiveTop(item)}
+              onKeyDown={e => handleKeyDown(e, i, item)}
+              onClick={() => setActiveTop(item)}
+            >
+              {item.label}
+            </button>
+          ))}
+        </nav>
+        <div className="flex items-center gap-3">
+          <Search className="h-5 w-5" aria-hidden />
+          <ShoppingCart className="h-5 w-5" aria-hidden />
+        </div>
+      </div>
+      {/* Mobile scrollable nav */}
+      <nav className="flex overflow-x-auto border-t px-4 md:hidden" role="menubar">
+        {visibleTops.map(item => (
+          <button
+            key={item.id}
+            role="menuitem"
+            aria-haspopup={item.groups ? true : undefined}
+            aria-expanded={activeTop?.id === item.id}
+            className="py-3 px-2 text-sm font-medium hover:text-primary focus:outline-none"
+            onClick={() =>
+              setActiveTop(activeTop?.id === item.id ? null : item)
+            }
+          >
+            {item.label}
+          </button>
+        ))}
+      </nav>
+      <MegaMenu
+        activeTopId={activeTop?.id ?? null}
+        groups={activeTop?.groups}
+        onClose={() => setActiveTop(null)}
+      />
+    </header>
+  );
+}
+

--- a/src/components/site/MegaMenu.tsx
+++ b/src/components/site/MegaMenu.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { MegaPanel } from './MegaPanel';
+import type { MegaGroup } from '@/lib/categories';
+
+interface MegaMenuProps {
+  activeTopId: string | null;
+  groups?: MegaGroup[];
+  onClose: () => void;
+}
+
+/**
+ * Wrapper that renders mega menu panels for desktop and mobile.
+ * - 데스크톱: 절대 위치, hover 유지
+ * - 모바일: 오버레이 + 바깥 클릭 시 닫힘
+ */
+export function MegaMenu({ activeTopId, groups, onClose }: MegaMenuProps) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  // Close on outside click (mobile)
+  useEffect(() => {
+    const handle = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+    if (activeTopId) {
+      document.addEventListener('mousedown', handle);
+    }
+    return () => document.removeEventListener('mousedown', handle);
+  }, [activeTopId, onClose]);
+
+  if (!activeTopId || !groups) return null;
+
+  return (
+    <>
+      {/* Desktop panel */}
+      <div
+        className="absolute left-0 top-full hidden w-full border-b bg-white shadow-md md:block"
+        onMouseLeave={onClose}
+      >
+        <MegaPanel groups={groups} />
+      </div>
+      {/* Mobile overlay */}
+      <div className="md:hidden" ref={ref}>
+        <div className="fixed inset-0 z-40 bg-black/30" />
+        <div className="fixed inset-x-0 top-12 z-50 max-h-[80vh] overflow-y-auto rounded-t-xl bg-white shadow-lg">
+          <MegaPanel groups={groups} />
+        </div>
+      </div>
+    </>
+  );
+}
+

--- a/src/components/site/MegaPanel.tsx
+++ b/src/components/site/MegaPanel.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import Link from 'next/link';
+import type { MegaGroup } from '@/lib/categories';
+
+interface MegaPanelProps {
+  groups: MegaGroup[];
+}
+
+/**
+ * Grid panel for mega menu groups.
+ * - 모바일에서는 2열, 데스크톱에서는 최대 4열까지 표시
+ */
+export function MegaPanel({ groups }: MegaPanelProps) {
+  return (
+    <div className="grid gap-4 p-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+      {groups.map(group => (
+        <div
+          key={group.id}
+          className="rounded-xl border bg-white p-4 shadow-sm md:p-5"
+        >
+          <h3 className="mb-2 font-semibold">{group.title}</h3>
+          <ul className="space-y-1 text-sm">
+            {group.items.map(item => (
+              <li key={item.id}>
+                <Link
+                  href={item.href}
+                  className="inline-flex items-center gap-1 hover:underline"
+                >
+                  <span>{item.label}</span>
+                  {item.badge && (
+                    <span className="rounded bg-primary px-1 text-[10px] uppercase text-primary-foreground">
+                      {item.badge}
+                    </span>
+                  )}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  );
+}
+

--- a/src/lib/categories.ts
+++ b/src/lib/categories.ts
@@ -74,3 +74,148 @@ export const categoriesMap: Record<string, { name: string; subCategories: Omit<S
   packaging: { name: '포장/부자재', subCategories: packagingSubNav.map(s => ({label: s.label, id: s.id})) },
   lanyard: { name: '랜야드', subCategories: [] },
 };
+
+export type MegaItem = {
+  id: string;
+  label: string;
+  href: string;
+  badge?: 'new' | 'hot' | 'sale' | null;
+};
+
+export type MegaGroup = {
+  id: string;
+  title: string;
+  items: MegaItem[];
+};
+
+export type MenuTop = {
+  id: string;
+  label: string;
+  slug?: string;
+  show: boolean;
+  order: number;
+  groups?: MegaGroup[];
+};
+
+export const menuTops: MenuTop[] = [
+  {
+    id: 'all',
+    label: 'ALL',
+    show: true,
+    order: 0,
+    groups: [
+      {
+        id: 'all-overview',
+        title: 'ALL',
+        items: [
+          { id: 'custom', label: '커스텀상품', href: '/all/custom' },
+          { id: 'promo', label: '단체판촉상품', href: '/all/promo' },
+          { id: 'ipgoods', label: 'IP굿즈 상품개발', href: '/ipgoods' },
+          { id: 'branding', label: '브랜딩상품개발', href: '/branding' },
+          { id: 'reviews', label: '리뷰', href: '/reviews' },
+          { id: 'guide', label: '상품주문 가이드', href: '/guide' },
+        ],
+      },
+      {
+        id: 'core',
+        title: '핵굿즈',
+        items: [
+          { id: 'acrylic', label: '아크릴 굿즈', href: '/acrylic' },
+          { id: 'paper', label: '지류 굿즈', href: '/paper' },
+          { id: 'sticker', label: '스티커(다꾸)', href: '/sticker' },
+          { id: 'pin-set', label: '핀/각종/세트', href: '/pin-set' },
+          { id: 'standee', label: '등신대', href: '/standee' },
+          { id: 'etc', label: 'ETC', href: '/etc' },
+        ],
+      },
+      {
+        id: 'promo-group',
+        title: '단체 판촉상품',
+        items: [
+          { id: 'mug', label: '머그컵/유리컵', href: '/promo/mug' },
+          { id: 'tumbler', label: '텀블러', href: '/promo/tumbler' },
+          { id: 'towel', label: '수건', href: '/promo/towel' },
+          { id: 'clock', label: '시계', href: '/promo/clock' },
+          { id: 'umbrella', label: '우산', href: '/promo/umbrella' },
+          { id: 'tshirt', label: '티셔츠', href: '/promo/tshirt' },
+        ],
+      },
+      {
+        id: 'sign',
+        title: '광고물/사인',
+        items: [
+          { id: 'led', label: 'LED 네온', href: '/sign/led' },
+          { id: 'banner', label: '현수막/디자인', href: '/sign/banner' },
+          { id: 'mini', label: '미니간판', href: '/sign/mini' },
+        ],
+      },
+      {
+        id: 'panel',
+        title: '판넬종류',
+        items: [
+          { id: 'frame', label: '액자/스탠딩/테이블', href: '/panel/frame' },
+          { id: 'cushion', label: '쿠션/천/석고보드 제품', href: '/panel/cushion' },
+          { id: 'decor', label: '장식용품', href: '/panel/decor' },
+        ],
+      },
+      {
+        id: 'packaging',
+        title: '포장 부자재',
+        items: [{ id: 'all', label: '전체보기', href: '/packaging' }],
+      },
+    ],
+  },
+  {
+    id: 'acrylic',
+    label: '아크릴',
+    show: true,
+    order: 1,
+    groups: [
+      {
+        id: 'acrylic-main',
+        title: '아크릴 굿즈',
+        items: [
+          { id: 'keyring', label: '아크릴키링', href: '/acrylic/keyring' },
+          { id: 'stand', label: '스탠드', href: '/acrylic/stand' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'paper',
+    label: '지류',
+    show: true,
+    order: 2,
+    groups: [
+      {
+        id: 'paper-main',
+        title: '지류 굿즈',
+        items: [
+          { id: 'poster', label: '포스터', href: '/paper/poster' },
+          { id: 'card', label: '카드', href: '/paper/card' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'sticker',
+    label: '스티커',
+    show: true,
+    order: 3,
+    groups: [
+      {
+        id: 'sticker-main',
+        title: '스티커',
+        items: [
+          { id: 'basic', label: '일반 스티커', href: '/sticker/basic', badge: 'new' },
+          { id: 'hologram', label: '홀로그램', href: '/sticker/holo' },
+        ],
+      },
+    ],
+  },
+  { id: 'clothes', label: '의류', show: true, order: 4 },
+  { id: 'ipgoods', label: 'IP굿즈 상품개발', show: true, order: 5 },
+  { id: 'branding', label: '브랜딩', show: true, order: 6 },
+  { id: 'promo', label: '단체판촉제품', show: true, order: 7 },
+];
+


### PR DESCRIPTION
## Summary
- add mega menu data structures and sample categories
- build responsive header with keyboard-friendly mega menu
- wire up header in root layout

## Testing
- `npm run type-check`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a82776ad1c83269966ef5370dd5704