### PR TITLE
refactor top banner and navigation

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,8 +4,9 @@ import Link from 'next/link';
 import { Palette } from 'lucide-react';
 import { Providers } from '@/components/providers';
 import { Header } from '@/components/site/Header';
+import { SubNav } from '@/components/SubNav';
 import { Footer } from '@/components/footer';
-import { TopBanner } from '@/components/top-banner';
+import { TopBanner } from '@/components/TopBanner';
 import { Toaster } from '@/components/ui/toaster';
 import { Button } from '@/components/ui/button';
 import { Chatbot } from '@/components/chatbot';
@@ -33,6 +34,7 @@ export default function RootLayout({
           <div className="flex min-h-screen flex-col">
             <TopBanner />
             <Header />
+            <SubNav />
             <main className="flex-grow bg-background">{children}</main>
             <Footer />
           </div>

--- a/src/components/SubNav.tsx
+++ b/src/components/SubNav.tsx
@@ -1,0 +1,26 @@
+export function SubNav() {
+  const items = [
+    { href: '/support/notice', label: '공지사항' },
+    { href: '/support/faq', label: '고객센터' },
+    { href: '/support/guide', label: '이용가이드' },
+    { href: '/events', label: '이벤트' },
+    { href: '/mypage/inquiries', label: '문의게시판' },
+    { href: '/resources', label: '자료실' },
+  ];
+  return (
+    <nav aria-label="Secondary" className="border-b bg-background text-xs text-muted-foreground">
+      <ul className="container mx-auto flex h-9 flex-wrap items-center gap-2 px-4">
+        {items.map((item, index) => (
+          <li key={item.href} className="flex items-center">
+            {index > 0 && <span className="mx-2">|</span>}
+            <a href={item.href} className="hover:underline">
+              {item.label}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}
+
+export default SubNav;

--- a/src/components/TopBanner.tsx
+++ b/src/components/TopBanner.tsx
@@ -6,11 +6,12 @@ import type { Banner } from '@/lib/types';
 import { cn } from '@/lib/utils';
 
 function getHideKey(id: string) {
-  return `banner_hide_${id}`;
+  return `pinto_top_banner_${id}_hide_until`;
 }
 
 export function TopBanner() {
   const [banner, setBanner] = useState<Banner | null>(null);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     async function fetchBanner() {
@@ -28,10 +29,16 @@ export function TopBanner() {
         setBanner(data);
       } catch (e) {
         console.error(e);
+      } finally {
+        setLoading(false);
       }
     }
     fetchBanner();
   }, []);
+
+  if (loading) {
+    return <div className="h-10 w-full animate-pulse bg-muted" />;
+  }
 
   if (!banner) return null;
 

--- a/src/components/site/Header.tsx
+++ b/src/components/site/Header.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { Search, ShoppingCart } from 'lucide-react';
 import { MegaMenu } from './MegaMenu';
-import { MenuTop, menuTops } from '@/lib/categories';
+import { TopMenu, topMenus } from '@/lib/nav';
 
 /**
  * 상단 헤더와 내비게이션 바를 렌더링합니다.
@@ -13,7 +13,7 @@ import { MenuTop, menuTops } from '@/lib/categories';
  * - 키보드: ←/→ 상단 이동, ↓ 열기, Esc 닫기
  */
 export function Header() {
-  const [activeTop, setActiveTop] = useState<MenuTop | null>(null);
+  const [activeTop, setActiveTop] = useState<TopMenu | null>(null);
   const [scrolled, setScrolled] = useState(false);
   const btnRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
@@ -23,12 +23,12 @@ export function Header() {
     return () => window.removeEventListener('scroll', onScroll);
   }, []);
 
-  const visibleTops = menuTops.filter(t => t.show).sort((a, b) => a.order - b.order);
+  const visibleTops = topMenus.filter(t => t.show).sort((a, b) => a.order - b.order);
 
   const handleKeyDown = (
     e: React.KeyboardEvent<HTMLButtonElement>,
     index: number,
-    item: MenuTop,
+    item: TopMenu,
   ) => {
     const max = visibleTops.length;
     switch (e.key) {

--- a/src/components/site/MegaMenu.tsx
+++ b/src/components/site/MegaMenu.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef } from 'react';
 import { MegaPanel } from './MegaPanel';
-import type { MegaGroup } from '@/lib/categories';
+import type { MegaGroup } from '@/lib/nav';
 
 interface MegaMenuProps {
   activeTopId: string | null;

--- a/src/components/site/MegaPanel.tsx
+++ b/src/components/site/MegaPanel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import type { MegaGroup } from '@/lib/categories';
+import type { MegaGroup } from '@/lib/nav';
 
 interface MegaPanelProps {
   groups: MegaGroup[];

--- a/src/lib/nav.ts
+++ b/src/lib/nav.ts
@@ -1,0 +1,142 @@
+export type MegaItem = {
+  id: string;
+  label: string;
+  href: string;
+  badge?: 'new' | 'hot' | 'sale' | null;
+};
+
+export type MegaGroup = {
+  id: string;
+  title: string;
+  items: MegaItem[];
+};
+
+export type TopMenu = {
+  id: string;
+  label: string;
+  order: number;
+  show: boolean;
+  groups?: MegaGroup[];
+};
+
+export const topMenus: TopMenu[] = [
+  {
+    id: 'all',
+    label: 'ALL',
+    order: 0,
+    show: true,
+    groups: [
+      {
+        id: 'all-overview',
+        title: 'ALL',
+        items: [
+          { id: 'custom', label: '커스텀상품', href: '/all/custom' },
+          { id: 'promo', label: '단체판촉상품', href: '/all/promo' },
+          { id: 'ipgoods', label: 'IP굿즈 상품개발', href: '/ipgoods' },
+          { id: 'branding', label: '브랜딩상품개발', href: '/branding' },
+          { id: 'reviews', label: '리뷰', href: '/reviews' },
+          { id: 'guide', label: '상품주문 가이드', href: '/guide' },
+        ],
+      },
+      {
+        id: 'core',
+        title: '팬굿즈',
+        items: [
+          { id: 'acrylic', label: '아크릴 굿즈', href: '/acrylic' },
+          { id: 'paper', label: '지류 굿즈', href: '/paper' },
+          { id: 'sticker', label: '스티커(다꾸)', href: '/sticker' },
+          { id: 'pin-set', label: '핀·각종·세트', href: '/pin-set' },
+          { id: 'standee', label: '등신대', href: '/standee' },
+          { id: 'etc', label: 'ETC', href: '/etc' },
+        ],
+      },
+      {
+        id: 'promo-group',
+        title: '단체 판촉상품',
+        items: [
+          { id: 'mug', label: '머그컵·유리컵', href: '/promo/mug' },
+          { id: 'tumbler', label: '텀블러', href: '/promo/tumbler' },
+          { id: 'towel', label: '수건', href: '/promo/towel' },
+          { id: 'clock', label: '시계', href: '/promo/clock' },
+          { id: 'umbrella', label: '우산', href: '/promo/umbrella' },
+          { id: 'tshirt', label: '티셔츠', href: '/promo/tshirt' },
+        ],
+      },
+      {
+        id: 'sign',
+        title: '광고물/사인',
+        items: [
+          { id: 'led', label: 'LED 네온', href: '/sign/led' },
+          { id: 'banner', label: '현수막·디자인', href: '/sign/banner' },
+          { id: 'mini', label: '미니간판', href: '/sign/mini' },
+        ],
+      },
+      {
+        id: 'panel',
+        title: '판넬종류',
+        items: [
+          { id: 'frame', label: '액자·스탠딩·테이블', href: '/panel/frame' },
+          { id: 'cushion', label: '쿠션·천·석고보드 제품', href: '/panel/cushion' },
+          { id: 'decor', label: '장식용품', href: '/panel/decor' },
+        ],
+      },
+      {
+        id: 'packaging',
+        title: '포장 부자재',
+        items: [{ id: 'all', label: '전체보기', href: '/packaging' }],
+      },
+    ],
+  },
+  {
+    id: 'acrylic',
+    label: '아크릴',
+    order: 1,
+    show: true,
+    groups: [
+      {
+        id: 'acrylic-main',
+        title: '아크릴 굿즈',
+        items: [
+          { id: 'keyring', label: '아크릴키링', href: '/acrylic/keyring' },
+          { id: 'stand', label: '스탠드', href: '/acrylic/stand' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'paper',
+    label: '지류',
+    order: 2,
+    show: true,
+    groups: [
+      {
+        id: 'paper-main',
+        title: '지류 굿즈',
+        items: [
+          { id: 'poster', label: '포스터', href: '/paper/poster' },
+          { id: 'card', label: '카드', href: '/paper/card' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'sticker',
+    label: '스티커',
+    order: 3,
+    show: true,
+    groups: [
+      {
+        id: 'sticker-main',
+        title: '스티커',
+        items: [
+          { id: 'basic', label: '일반 스티커', href: '/sticker/basic', badge: 'new' },
+          { id: 'hologram', label: '홀로그램', href: '/sticker/holo' },
+        ],
+      },
+    ],
+  },
+  { id: 'clothes', label: '의류', order: 4, show: true },
+  { id: 'ipgoods', label: 'IP굿즈 상품개발', order: 5, show: true },
+  { id: 'branding', label: '브랜딩', order: 6, show: true },
+  { id: 'promo', label: '단체판촉제품', order: 7, show: true },
+];


### PR DESCRIPTION
## Summary
- update top banner to respect hide-until key and show loading skeleton
- centralize menu structure in `src/lib/nav.ts`
- add secondary navigation bar with common support links

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68a82bfcde6883268f4905372ed1c78d