### PR TITLE
feat: add hero banner carousel

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import Image from 'next/image';
+import { TopBanner, type HeroBanner } from '@/components/TopBanner';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { CategoryShortcuts } from '@/components/category-shortcuts';
@@ -9,20 +10,18 @@ import { useProductContext } from '@/contexts/product-context';
 import type { Product } from '@/lib/types';
 import { ChevronRight } from 'lucide-react';
 
-const heroBanners = [
+const heroBanners: HeroBanner[] = [
   {
     id: '1',
     href: '#',
     alt: 'Hand holding a wooden whale craft.',
     imgSrc: 'https://placehold.co/1600x1200.png',
-    hint: 'wooden whale craft',
   },
   {
     id: '2',
     href: '#',
     alt: 'Custom wooden coasters with map engravings.',
     imgSrc: 'https://placehold.co/1600x1200.png',
-    hint: 'custom wooden coasters',
   },
 ];
 
@@ -92,25 +91,8 @@ export default function Home() {
   return (
   <div className="flex flex-col bg-slate-50 dark:bg-slate-900 min-h-screen px-8 md:px-16">
       {/* HERO */}
-  <section className="pt-8">
-        <div className="grid grid-cols-1 md:grid-cols-2">
-          {heroBanners.map(banner => (
-            <Link
-              key={banner.id}
-              href={banner.href}
-              className="group relative block h-[500px] w-full overflow-hidden md:h-[800px]"
-            >
-              <Image
-                src={banner.imgSrc}
-                alt={banner.alt}
-                fill
-                priority
-                className="object-cover transition-transform duration-300 group-hover:scale-105"
-                sizes="(max-width: 768px) 100vw, 50vw"
-              />
-            </Link>
-          ))}
-        </div>
+      <section className="pt-8">
+        <TopBanner banners={heroBanners} />
       </section>
 
       {/* SHORTCUTS */}

--- a/src/components/TopBanner.tsx
+++ b/src/components/TopBanner.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Image from 'next/image';
+import Link from 'next/link';
+import type { CarouselApi } from '@/components/ui/carousel';
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+} from '@/components/ui/carousel';
+
+export type HeroBanner = {
+  id: string;
+  href: string;
+  imgSrc: string;
+  alt: string;
+};
+
+interface TopBannerProps {
+  banners: HeroBanner[];
+}
+
+function chunk<T>(arr: T[], size: number): T[][] {
+  const res: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) {
+    res.push(arr.slice(i, i + size));
+  }
+  return res;
+}
+
+export function TopBanner({ banners }: TopBannerProps) {
+  const [api, setApi] = useState<CarouselApi>();
+  const [current, setCurrent] = useState(0);
+
+  const slides = chunk(banners, 2);
+
+  useEffect(() => {
+    if (!api) return;
+    const onSelect = () => setCurrent(api.selectedScrollSnap());
+    api.on('select', onSelect);
+    const autoplay = setInterval(() => api.scrollNext(), 5000);
+    return () => {
+      api.off('select', onSelect);
+      clearInterval(autoplay);
+    };
+  }, [api]);
+
+  return (
+    <div className="relative">
+      <Carousel opts={{ loop: true }} setApi={setApi} className="w-full">
+        <CarouselContent>
+          {slides.map((group, idx) => (
+            <CarouselItem key={idx}>
+              <div className="grid grid-cols-1 md:grid-cols-2">
+                {group.map(b => (
+                  <Link
+                    key={b.id}
+                    href={b.href}
+                    className="relative block w-full aspect-[4/3] overflow-hidden"
+                  >
+                    <Image
+                      src={b.imgSrc}
+                      alt={b.alt}
+                      fill
+                      sizes="(max-width:768px) 100vw, 50vw"
+                      className="object-cover"
+                    />
+                  </Link>
+                ))}
+              </div>
+            </CarouselItem>
+          ))}
+        </CarouselContent>
+      </Carousel>
+      <div className="absolute bottom-2 left-1/2 flex -translate-x-1/2 gap-2">
+        {slides.map((_, i) => (
+          <button
+            key={i}
+            aria-label={`Go to slide ${i + 1}`}
+            onClick={() => api?.scrollTo(i)}
+            className={`h-2 w-2 rounded-full ${
+              current === i ? 'bg-black' : 'bg-gray-300'
+            }`}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default TopBanner;
+


### PR DESCRIPTION
## Summary
- add TopBanner carousel component with autoplay and dot navigation
- render TopBanner on homepage hero section

## Testing
- `pnpm lint` *(fails: Error when performing request to registry)*
- `pnpm type-check` *(fails: Error when performing request to registry)*

------
https://chatgpt.com/codex/tasks/task_e_68ab45bc0a0883268cdeaed2d1c02798