### PR TITLE
feat: add persistent ribbon banner hide options

### DIFF
--- a/README-banner.md
+++ b/README-banner.md
@@ -5,7 +5,7 @@ This module provides a dismissible banner shown at the top of the home page.
 ## Behavior
 - Fetches the active banner from `/api/banners/active` with `no-store` caching.
 - Shows a skeleton for at least 300 ms while loading.
-- Users can hide the banner for a day or a week using localStorage with key `pinto_banner_hide_until__{id}`.
+- Users can hide the banner for today or for a week via checkboxes. The hide timestamp is stored in `localStorage` under `banner:<id>:hideUntil` (ISO string). Closing without selecting a duration hides it only for the current session using `sessionStorage` key `banner:<id>:closed`.
 - Supports color, gradient or image backgrounds.
 - Accessible via keyboard with roles and labels.
 

--- a/src/components/TopStripBanner.tsx
+++ b/src/components/TopStripBanner.tsx
@@ -3,13 +3,21 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { X } from 'lucide-react';
-import { Banner, isHidden, setHideUntil } from '@/lib/banner';
+import { usePathname } from 'next/navigation';
+import {
+  Banner,
+  isHidden,
+  setHideUntil,
+  setSessionClosed,
+} from '@/lib/banner';
 import '@/styles/banner.css';
 
 export function TopStripBanner() {
   const [banner, setBanner] = useState<Banner | null>(null);
   const [loading, setLoading] = useState(true);
+  const [hideToday, setHideToday] = useState(false);
   const [hideWeek, setHideWeek] = useState(false);
+  const pathname = usePathname();
 
   useEffect(() => {
     let mounted = true;
@@ -23,6 +31,11 @@ export function TopStripBanner() {
         if (!data.isOpen) return;
         if (!isHidden(data.id) && mounted) {
           setBanner(data);
+          console.log('banner_impression', {
+            id: data.id,
+            route: pathname,
+            timestamp: new Date().toISOString(),
+          });
         }
       } catch (err) {
         console.warn('TopStripBanner: failed to load banner', err);
@@ -43,8 +56,38 @@ export function TopStripBanner() {
 
   const handleClose = () => {
     if (!banner) return;
-    const duration = hideWeek ? 7 * 24 * 60 * 60 * 1000 : 24 * 60 * 60 * 1000;
-    setHideUntil(banner.id, duration);
+
+    if (hideWeek) {
+      const until = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+      setHideUntil(banner.id, until);
+      console.log('banner_close', {
+        id: banner.id,
+        choice: 'week',
+      });
+    } else if (hideToday) {
+      const now = new Date();
+      const until = new Date(
+        now.getFullYear(),
+        now.getMonth(),
+        now.getDate(),
+        23,
+        59,
+        59,
+        999,
+      );
+      setHideUntil(banner.id, until);
+      console.log('banner_close', {
+        id: banner.id,
+        choice: 'today',
+      });
+    } else {
+      setSessionClosed(banner.id);
+      console.log('banner_close', {
+        id: banner.id,
+        choice: 'session',
+      });
+    }
+
     setBanner(null);
   };
 
@@ -83,7 +126,7 @@ export function TopStripBanner() {
       className={`w-full shadow-sm ring-1 ring-white/40 ${getTextColor()}`}
       style={style}
     >
-      <div className="flex w-full h-11 md:h-12 items-center justify-center px-0 text-xs md:text-sm relative">
+      <div className="flex w-full min-h-[40px] md:min-h-[56px] max-h-[64px] md:max-h-[80px] items-center justify-center px-0 text-xs md:text-sm relative py-2 md:py-3">
         {/* 중앙 메시지 */}
         <div className="w-full flex items-center justify-center absolute left-0 top-0 h-full pointer-events-none">
           <span className="font-semibold text-center w-full block pointer-events-auto">
@@ -96,21 +139,31 @@ export function TopStripBanner() {
             )}
           </span>
         </div>
-        {/* 오른쪽: 일주일간 보지 않기 & 닫기 */}
+        {/* 오른쪽: 체크박스 & 닫기 */}
         {banner.canClose && (
           <div className="flex items-center gap-2 whitespace-nowrap absolute right-4 md:right-5 top-1/2 -translate-y-1/2 bg-transparent z-10">
             <input
-              id="hide7d"
+              id="hideToday"
+              type="checkbox"
+              className="h-4 w-4"
+              checked={hideToday}
+              onChange={e => setHideToday(e.target.checked)}
+            />
+            <label htmlFor="hideToday" className="cursor-pointer select-none text-xs">
+              오늘하루 보지 않기
+            </label>
+            <input
+              id="hideWeek"
               type="checkbox"
               className="h-4 w-4"
               checked={hideWeek}
               onChange={e => setHideWeek(e.target.checked)}
             />
-            <label htmlFor="hide7d" className="cursor-pointer select-none text-xs">
-              일주일간 보지 않기
+            <label htmlFor="hideWeek" className="cursor-pointer select-none text-xs">
+              일주일 간 보지 않기
             </label>
             <button
-              aria-label="배너 닫기"
+              aria-label="띠배너 닫기"
               onClick={handleClose}
               className="p-1 hover:opacity-80"
             >

--- a/src/lib/banner.ts
+++ b/src/lib/banner.ts
@@ -10,33 +10,64 @@ export type Banner = {
   updatedAt?: string;
 };
 
-const PREFIX = 'pinto_banner_hide_until__';
+const HIDE_PREFIX = 'banner:';
+const HIDE_SUFFIX = ':hideUntil';
+const SESSION_SUFFIX = ':closed';
 
-export function getHideKey(id: string): string {
-  return `${PREFIX}${id}`;
+function hideKey(id: string): string {
+  return `${HIDE_PREFIX}${id}${HIDE_SUFFIX}`;
+}
+
+function sessionKey(id: string): string {
+  return `${HIDE_PREFIX}${id}${SESSION_SUFFIX}`;
 }
 
 export function getHideUntil(id: string): number | null {
   if (typeof window === 'undefined') return null;
   try {
-    const stored = window.localStorage.getItem(getHideKey(id));
-    return stored ? parseInt(stored, 10) : null;
+    const stored = window.localStorage.getItem(hideKey(id));
+    if (!stored) return null;
+    const ts = Date.parse(stored);
+    if (isNaN(ts) || ts <= Date.now()) {
+      window.localStorage.removeItem(hideKey(id));
+      return null;
+    }
+    return ts;
   } catch {
     return null;
   }
 }
 
-export function setHideUntil(id: string, msFromNow: number): void {
+export function setHideUntil(id: string, until: Date): void {
   if (typeof window === 'undefined') return;
   try {
-    const ts = Date.now() + msFromNow;
-    window.localStorage.setItem(getHideKey(id), String(ts));
+    window.localStorage.setItem(hideKey(id), until.toISOString());
   } catch {
     // ignore
   }
 }
 
+export function setSessionClosed(id: string): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.sessionStorage.setItem(sessionKey(id), '1');
+  } catch {
+    // ignore
+  }
+}
+
+function isSessionClosed(id: string): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    return window.sessionStorage.getItem(sessionKey(id)) === '1';
+  } catch {
+    return false;
+  }
+}
+
 export function isHidden(id: string): boolean {
   const ts = getHideUntil(id);
-  return ts !== null && ts > Date.now();
+  return (ts !== null && ts > Date.now()) || isSessionClosed(id);
 }
+
+export { hideKey as getHideKey };

--- a/src/styles/banner.css
+++ b/src/styles/banner.css
@@ -1,3 +1,3 @@
 .banner-skeleton {
-  @apply h-11 md:h-12 w-full bg-gray-200 animate-pulse;
+  @apply w-full bg-gray-200 animate-pulse min-h-[40px] md:min-h-[56px] py-2 md:py-3;
 }


### PR DESCRIPTION
## Summary
- add today/week/session hiding to top strip banner with tracking events
- store banner dismissal state in localStorage/sessionStorage using banner:<id> keys
- document updated banner behavior and styles

## Testing
- `npm run lint` *(fails: colorDist assigned value but never used, etc.)*
- `npm run type-check` *(fails: cannot find module '@prisma/client', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68ab4a6974a88326b9e0e5515bb45f09