### PR TITLE
Remove unused react-hot-toast integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "lucide-react": "^0.475.0",
     "next": "15.3.3",
     "patch-package": "^8.0.0",
-    "react-hot-toast": "^2.4.1",
     "react": "^18.3.1",
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,7 +6,6 @@ import { Providers } from '@/components/providers';
 import { Header } from '@/components/header';
 import { Footer } from '@/components/footer';
 import { Toaster as RadixToaster } from '@/components/ui/toaster';
-import { Toaster as HotToaster } from 'react-hot-toast';
 import { Button } from '@/components/ui/button';
 import { Chatbot } from '@/components/chatbot';
 import './globals.css';
@@ -36,7 +35,6 @@ export default function RootLayout({
             <Footer />
           </div>
           <RadixToaster />
-          <HotToaster />
           <div className="fixed bottom-6 left-6 z-50">
             <Button asChild size="lg" className="rounded-full shadow-lg">
               <Link href="/editor">


### PR DESCRIPTION
## Summary
- remove react-hot-toast from RootLayout
- drop react-hot-toast dependency

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab5c4b6a90832685b9200d0d760968