### PR TITLE
chore: bootstrap prisma with repository interface

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,7 +23,10 @@ DB_USER=PLACEHOLDER
 DB_PASSWORD=PLACEHOLDER
 DB_NAME=PLACEHOLDER
 
-# Prisma (SQLite default)
-DATABASE_URL="file:./dev.db"
+# Prisma
+# MySQL connection string used by Prisma
+DATABASE_URL="mysql://user:pass@localhost:3306/db"
 
-# PR0: 없음
+# Data driver: choose between 'firestore' and 'prisma'
+DATA_DRIVER=firestore
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,4 +1,6 @@
-generator client { provider = "prisma-client-js" }
+generator client {
+  provider = "prisma-client-js"
+}
 
 datasource db {
   provider = "mysql"

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,4 +1,12 @@
 export const runtime = 'nodejs';
+
+import { productRepository } from '@/server/repositories';
+
 export async function GET() {
-  return new Response('ok');
+  try {
+    await productRepository.ping();
+    return new Response('ok');
+  } catch (err) {
+    return new Response('unhealthy', { status: 500 });
+  }
 }

--- a/src/server/repositories/drivers/firestore.ts
+++ b/src/server/repositories/drivers/firestore.ts
@@ -1,0 +1,38 @@
+import { getFirestore } from '@/lib/firebase.admin';
+import type { Banner } from '@/lib/banner';
+import type { Product, Order } from '@/lib/types';
+import type {
+  ProductRepository,
+  BannerRepository,
+  OrderRepository,
+} from '../types';
+
+const db = getFirestore();
+
+async function ping(): Promise<void> {
+  await db.doc('_meta/ping').get();
+}
+
+export const productRepository: ProductRepository = {
+  async findById(id) {
+    const snap = await db.collection('products').doc(id).get();
+    return snap.exists ? (snap.data() as Product) : null;
+  },
+  ping,
+};
+
+export const bannerRepository: BannerRepository = {
+  async findById(id) {
+    const snap = await db.collection('banners').doc(id).get();
+    return snap.exists ? (snap.data() as Banner) : null;
+  },
+  ping,
+};
+
+export const orderRepository: OrderRepository = {
+  async findById(id) {
+    const snap = await db.collection('orders').doc(id).get();
+    return snap.exists ? (snap.data() as Order) : null;
+  },
+  ping,
+};

--- a/src/server/repositories/drivers/prisma.ts
+++ b/src/server/repositories/drivers/prisma.ts
@@ -1,0 +1,30 @@
+import { PrismaClient } from '@prisma/client';
+import type { ProductRepository, BannerRepository, OrderRepository } from '../types';
+
+const prisma = new PrismaClient();
+
+async function ping(): Promise<void> {
+  await prisma.$queryRaw`SELECT 1`;
+}
+
+export const productRepository: ProductRepository = {
+  async findById(_id) {
+    // TODO: implement when Product model is added
+    return null;
+  },
+  ping,
+};
+
+export const bannerRepository: BannerRepository = {
+  async findById(_id) {
+    return null;
+  },
+  ping,
+};
+
+export const orderRepository: OrderRepository = {
+  async findById(_id) {
+    return null;
+  },
+  ping,
+};

--- a/src/server/repositories/index.ts
+++ b/src/server/repositories/index.ts
@@ -1,0 +1,17 @@
+import type { ProductRepository, BannerRepository, OrderRepository } from './types';
+import * as firestore from './drivers/firestore';
+import * as prisma from './drivers/prisma';
+
+const usePrisma = process.env.DATA_DRIVER === 'prisma';
+
+export const productRepository: ProductRepository = usePrisma
+  ? prisma.productRepository
+  : firestore.productRepository;
+
+export const bannerRepository: BannerRepository = usePrisma
+  ? prisma.bannerRepository
+  : firestore.bannerRepository;
+
+export const orderRepository: OrderRepository = usePrisma
+  ? prisma.orderRepository
+  : firestore.orderRepository;

--- a/src/server/repositories/types.ts
+++ b/src/server/repositories/types.ts
@@ -1,0 +1,17 @@
+import type { Banner } from '@/lib/banner';
+import type { Product, Order } from '@/lib/types';
+
+export interface ProductRepository {
+  findById(id: string): Promise<Product | null>;
+  ping(): Promise<void>;
+}
+
+export interface BannerRepository {
+  findById(id: string): Promise<Banner | null>;
+  ping(): Promise<void>;
+}
+
+export interface OrderRepository {
+  findById(id: string): Promise<Order | null>;
+  ping(): Promise<void>;
+}


### PR DESCRIPTION
## Summary
- add DATA_DRIVER and DATABASE_URL placeholders
- introduce repository interfaces with Firestore and Prisma drivers
- wire health endpoint to repository ping

## Testing
- `npx prisma generate`
- `DATABASE_URL="mysql://root:password@localhost:3306/test" npx prisma migrate dev --name init` *(fails: Can't reach database server)*
- `npm test` *(fails: expect is not defined)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68ad687719d883269453277830a0cdfc